### PR TITLE
Add support to OSX

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
 
   "os": [
-    "linux"
+    "linux", "darwin"
   ],
 
   "scripts": {

--- a/resources/spec.ejs
+++ b/resources/spec.ejs
@@ -4,6 +4,7 @@
 <% } %><% if (description) { %>Summary: <%= description %>
 <% } %><% if (homepage) { %>URL: <%= homepage %>
 <% } %><% if (license) { %>License: <%= license %>
+<% } %><% if (categories) { %>Group: Applications/<%= categories[0] %>
 <% } %>
 AutoReqProv: no
 <% if (requires) { %>Requires: <%= requires.join(', ') %>


### PR DESCRIPTION
Hello,

I need to build some `.rpm` packages on OSX, would be great if you could accept this PR! :)

The changes are basically add `darwin` to the _os_ parameter on `package.json` and add the `Group` field to the spec file because as you can see is required by `rpmbuild` on OSX:

```
Running "electron-redhat-installer:linux32" (electron-redhat-installer) task
Creating package (this may take a while)
Warning: Error executing command (1):
rpmbuild -bb /var/folders/3z/1fts6mxx2_7_5g91kn54qw3w0000gn/T/electron-115817-37918-1015qoi/hackhands_1.4.13_x86/SPECS/hackhands.spec --target x86
error: Group field must be present in package: (main package)
error: Package has no %description: app-1.4.13-1.x86
 Use --force to continue.

Aborted due to warnings.
```

I implemented the `Group` field as decribed [here](http://www.rpm.org/max-rpm/s1-rpm-build-creating-spec-file.html).

Thank you!
